### PR TITLE
ACS-6432 Update docker compose with ADW and ACC

### DIFF
--- a/distribution/src/main/resources/docker-compose-origin/.env
+++ b/distribution/src/main/resources/docker-compose-origin/.env
@@ -6,6 +6,7 @@ TRANSFORM_CORE_AIO_TAG=${dist.transform.core.aio.version}
 SHARED_FILE_STORE_TAG=${dist.transform.sfs.version}
 ACTIVE_MQ_TAG=${dist.activemq.docker.tag}
 DIGITAL_WORKSPACE_TAG=${dist.digital.workspace.version}
+CONTROL_CENTER_TAG=${dist.control.center.version}
 ACS_NGINX_TAG=${dist.nginx.version}
 ELASTICSEARCH_TAG=${dist.elasticsearch.version}
 SEARCH_ENTERPRISE_TAG=${dist.search.enterprise.version}

--- a/distribution/src/main/resources/docker-compose/docker-compose.yml
+++ b/distribution/src/main/resources/docker-compose/docker-compose.yml
@@ -124,20 +124,36 @@ services:
     image: quay.io/alfresco/alfresco-digital-workspace:${DIGITAL_WORKSPACE_TAG}
     mem_limit: 128m
     environment:
-      BASEPATH: ./
+      APP_CONFIG_PROVIDER: "ECM"
+      APP_CONFIG_AUTH_TYPE: "BASIC"
+      BASE_PATH: ./
+      APP_BASE_SHARE_URL: "http://localhost:8080/workspace/#/preview/s"
+
+  control-center:
+    image: quay.io/alfresco/alfresco-control-center:${CONTROL_CENTER_TAG}
+    mem_limit: 128m
+    environment:
+      APP_CONFIG_PROVIDER: "ECM"
+      APP_CONFIG_AUTH_TYPE: "BASIC"
+      BASE_PATH: ./
 
   # HTTP proxy to provide HTTP Default port access to services
   proxy:
-    image: quay.io/alfresco/alfresco-acs-nginx:${ACS_NGINX_TAG}
+    image: alfresco/alfresco-acs-nginx:${ACS_NGINX_TAG}
     mem_limit: 128m
+    environment:
+      DISABLE_SYNCSERVICE: "true"
     depends_on:
       - alfresco
+      - digital-workspace
+      - control-center
     ports:
       - 8080:8080
     links:
       - digital-workspace
       - alfresco
       - share
+      - control-center
 
   elasticsearch:
     image: elasticsearch:${ELASTICSEARCH_TAG}

--- a/pom.xml
+++ b/pom.xml
@@ -68,8 +68,9 @@
     <dist.transform.sfs.version>4.0.1</dist.transform.sfs.version>
     <dist.activemq.version>5.18.3</dist.activemq.version>
     <dist.activemq.docker.tag>${dist.activemq.version}-jre17-rockylinux8</dist.activemq.docker.tag>
-    <dist.digital.workspace.version>4.3.0</dist.digital.workspace.version>
-    <dist.nginx.version>3.0.0</dist.nginx.version>
+    <dist.digital.workspace.version>4.4.0-7099328816</dist.digital.workspace.version>
+    <dist.control.center.version>8.3.0</dist.control.center.version>
+    <dist.nginx.version>3.4.2</dist.nginx.version>
     <dist.elasticsearch.version>7.17.3</dist.elasticsearch.version>
     <dist.search.enterprise.version>4.0.0.1</dist.search.enterprise.version>
     <dist.localstack.version>3.0.2</dist.localstack.version>


### PR DESCRIPTION
Update Alfresco Digital Workspace and add Alfresco Control Center in docker compose. Add specific versions to pom. Add tags to .env file.
ACC can be reached via: 
http://localhost:8080/admin
as there is small issue with URL for control center [OPSEXP-2419](https://alfresco.atlassian.net/browse/OPSEXP-2419)


[OPSEXP-2419]: https://alfresco.atlassian.net/browse/OPSEXP-2419?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ